### PR TITLE
Python 3 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,11 @@
 
 ## How to install
 
-```
+```sh
 git clone https://github.com/egison/egison_kernel.git
-pip install egison_kernel
-python -m egison_kernel.install
+cd egison_kernel
+pip install .  # install dependencies
+python -m egison_kernel.install  # install Egison kernel itself
 ```
 
 After that, copy `egison_kernel/codemirror/mode/egison/egison.js` to Jupyter's CodeMirror directory.

--- a/egison_kernel/install.py
+++ b/egison_kernel/install.py
@@ -6,16 +6,16 @@ import argparse
 from jupyter_client.kernelspec import KernelSpecManager
 from IPython.utils.tempdir import TemporaryDirectory
 
-kernel_json = {"argv":[sys.executable,"-m","egison_kernel", "-f", "{connection_file}"],
- "display_name":"Egison",
- "language":"egison",
- "codemirror_mode":"egison",
- "env":{"PS1": "$"}
-}
+kernel_json = {"argv": [sys.executable, "-m", "egison_kernel", "-f", "{connection_file}"],
+               "display_name": "Egison",
+               "language": "egison",
+               "codemirror_mode": "egison",
+               "env": {"PS1": "$"}}
+
 
 def install_my_kernel_spec(user=True, prefix=None):
     with TemporaryDirectory() as td:
-        os.chmod(td, 0o755) # Starts off as 700, not user readable
+        os.chmod(td, 0o755)  # Starts off as 700, not user readable
         with open(os.path.join(td, 'kernel.json'), 'w') as f:
             json.dump(kernel_json, f, sort_keys=True)
         # TODO: Copy resources once they're specified
@@ -23,11 +23,13 @@ def install_my_kernel_spec(user=True, prefix=None):
         print('Installing IPython kernel spec')
         KernelSpecManager().install_kernel_spec(td, 'egison', user=user, replace=True, prefix=prefix)
 
+
 def _is_root():
     try:
         return os.geteuid() == 0
     except AttributeError:
-        return False # assume not an admin on non-Unix platforms
+        return False  # assume not an admin on non-Unix platforms
+
 
 def main(argv=None):
     parser = argparse.ArgumentParser(
@@ -64,6 +66,7 @@ def main(argv=None):
         user = True
 
     install_my_kernel_spec(user=user, prefix=prefix)
+
 
 if __name__ == '__main__':
     main()

--- a/egison_kernel/kernel.py
+++ b/egison_kernel/kernel.py
@@ -15,6 +15,7 @@ __version__ = '0.0.1'
 version_pat = re.compile(r'(\d+(\.\d+)+)')
 crlf_pat = re.compile(r'[\r\n]+')
 
+
 class EgisonKernel(Kernel):
     implementation = 'egison_kernel'
     implementation_version = __version__
@@ -28,22 +29,18 @@ class EgisonKernel(Kernel):
             self._language_version = m.group(1)
         return self._language_version
 
-
     @property
     def banner(self):
         return u'Simple Egison Kernel (Egison v%s)' % self.language_version
-
 
     language_info = {'name': 'egison',
                      'codemirror_mode': 'egison',
                      'mimetype': 'text/plain',
                      'file_extension': '.egi'}
 
-
     def __init__(self, **kwargs):
         Kernel.__init__(self, **kwargs)
         self._start_egison()
-
 
     def _start_egison(self):
         # Signal handlers are inherited by forked processes, and we can't easily
@@ -53,11 +50,10 @@ class EgisonKernel(Kernel):
         sig = signal.signal(signal.SIGINT, signal.SIG_DFL)
         prompt = uuid.uuid4().hex + ">"
         try:
-            self.egisonwrapper = replwrap.REPLWrapper("egison -M latex --prompt " + prompt, 
-                unicode(prompt), None)
+            self.egisonwrapper = replwrap.REPLWrapper("egison -M latex --prompt " + prompt,
+                                                      unicode(prompt), None)
         finally:
             signal.signal(signal.SIGINT, sig)
-
 
     def do_execute(self, code, silent, store_history=True,
                    user_expressions=None, allow_stdin=False):
@@ -81,7 +77,7 @@ class EgisonKernel(Kernel):
         if not silent:
             moutput = re.match(r'\#latex\|(.*)\|\#', output)
             if moutput:
-                content = {'execution_count': self.execution_count, 'data': { 'text/html': u'{}'.format(u'$$' + moutput.group(1) + u'$$') }, 'metadata': {}}
+                content = {'execution_count': self.execution_count, 'data': {'text/html': u'{}'.format(u'$$' + moutput.group(1) + u'$$')}, 'metadata': {}}
                 self.send_response(self.iopub_socket, 'display_data', content)
             else:
                 stream_content = {'execution_count': self.execution_count, 'name': 'stdout', 'text': output}

--- a/egison_kernel/kernel.py
+++ b/egison_kernel/kernel.py
@@ -5,6 +5,7 @@
 from ipykernel.kernelbase import Kernel
 from pexpect import replwrap, EOF
 from subprocess import check_output
+from builtins import str as text
 
 import re
 import signal
@@ -51,7 +52,7 @@ class EgisonKernel(Kernel):
         prompt = uuid.uuid4().hex + ">"
         try:
             self.egisonwrapper = replwrap.REPLWrapper("egison -M latex --prompt " + prompt,
-                                                      unicode(prompt), None)
+                                                      text(prompt), None)
         finally:
             signal.signal(signal.SIGINT, sig)
 

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ setup(name='egison_kernel',
       install_requires=[
           'ipykernel',
           'pexpect',
+          'future'
       ],
       author='Satoshi Egi',
       author_email='egi@egison.org',

--- a/setup.py
+++ b/setup.py
@@ -4,10 +4,10 @@ from setuptools import setup, find_packages
 setup(name='egison_kernel',
       version='0.0.1',
       description='Egison Kernel for Jupyter Notebook',
-      install_requires = [
-            'ipykernel',
-            'pexpect',
-            ],
+      install_requires=[
+          'ipykernel',
+          'pexpect',
+      ],
       author='Satoshi Egi',
       author_email='egi@egison.org',
       url='https://github.com/egison/egison_kernel',


### PR DESCRIPTION
Plus, in a middle of the installation, I have noticed that `pip install egison_kernel` does not work because this packages is not published in PyPI. (By contrast, `bash_kernel` is in PyPI, though.) So, this PR updates README accordingly.

BTW, in my humble opinion, since sample `.ipynb` files make the repository messy, creating `notebooks/` directory and putting all `.ipynb` files in it might be a good idea :)